### PR TITLE
Add Daylight library product in Package.swift

### DIFF
--- a/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+++ b/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/Package.swift
+++ b/Package.swift
@@ -3,6 +3,12 @@ import PackageDescription
 
 let package = Package(
     name: "Daylight",
+    products: [
+        .library(
+            name: "Daylight",
+            targets: ["Daylight"]
+        ),
+    ],
     targets: [
         .target(
             name: "Daylight",


### PR DESCRIPTION
This pull request completes the products section in `Package.swift` by adding a Daylight library product that exposes the existing target .

